### PR TITLE
Add trim() function that trims space

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $ curl "localhost:3000/search?query=hellokitty"
   * a regex in form `s/abc/xyz/` - searches the text of the current DOM context and replaces with the provided text (sed-like syntax).
   * an attribute in the form `@abc` - gets the attribute `abc` from the DOM context.
   * a function in the form `html()` - gets the DOM context as string
+  * a function in the form `trim()` - trims space from the beginning and the end of the string
   * a query param in the form `query-param(abc)` - parses the current context as a URL and extracts the provided param
   * a css selector `abc` (if not in the forms above) alters the DOM context.
 * `list` - **Optional** A css selector used to split the root DOM context into a set of DOM contexts. Useful for capturing search results.

--- a/scraper/extractors.go
+++ b/scraper/extractors.go
@@ -229,6 +229,17 @@ var generators = []struct {
 			}, nil
 		},
 	},
+	//trim generator
+	{
+		match: func(extractor string) bool {
+			return extractor == "trim()"
+		},
+		generate: func(_ string) (extractorFn, error) {
+			return func(value string, sel *goquery.Selection) (string, *goquery.Selection) {
+				return strings.TrimSpace(value), sel
+			}, nil
+		},
+	},
 	//query param generator
 	{
 		match: func(extractor string) bool {


### PR DESCRIPTION
This PR adds a trim() function that can be used to trim space from the beginning and the end of the string

Example:
```json
"content": ["p", "trim()"]
```